### PR TITLE
Ajustado o retorno da fase

### DIFF
--- a/Mini02/PrincipalViewController.swift
+++ b/Mini02/PrincipalViewController.swift
@@ -8,6 +8,10 @@
 
 import UIKit
 
+func zeraContadorBanco(){
+    contadorBanco = 0
+}
+
 var situacao = " Pendente "
 
 let atualizaRendimentosNotificationKey = "co.gusrigor.atualizaRendimento"
@@ -44,6 +48,7 @@ class ViewController: UIViewController {
         atualizaSemestre()
         atualizaSituacao()
         observer()
+        zeraContadorBanco()
         // Do any additional setup after loading the view.
     }
   


### PR DESCRIPTION
Ao entrar no banco após uma fase, a interface estava alterada como se o jogador estivesse dentro de uma fase. Corrigido zerando o contadorBanco.